### PR TITLE
Readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@
 | :large_orange_diamond: | [Download SmartSeq2 expression matrix as an input to scanpy](tasks/Download%20Expression%20Matrix%20for%20Scanpy) |
 | :full_moon: | [Find out how many liver (whatever) cells are available](tasks/Find%20Cell%20Type%20Count) |
 | :full_moon: | [Download all bundles for T-cells sequenced with 10x](tasks/Download%2010x%20Seq%20T-cell%20Bundles) |
+| :white_check_mark: | [Use scanpy to explore an expression matrix downloaded from the HCA browser](nov18_demo) |
+| :white_circle: | Additional scanpy/seurat examples with expression matrix downloaded from the HCA browser: Filter matrix |
+| :white_circle: | Additional scanpy/seurat examples with expression matrix downloaded from HCA browser: Identify marker genes |
+| :white_circle: | Download specific json ingest metadata in tabular format, and relate to an expression matrix |
 | :large_orange_diamond: | Compare QC metrics between one experiment and another |
 | :white_circle: | Check gene expression of key markers for immune cells |
 | :white_circle: | Compare averaged gene expression of neurons to bulk controls |

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@
 | :large_orange_diamond: | [Download SmartSeq2 expression matrix as an input to scanpy](tasks/Download%20Expression%20Matrix%20for%20Scanpy) |
 | :full_moon: | [Find out how many liver (whatever) cells are available](tasks/Find%20Cell%20Type%20Count) |
 | :full_moon: | [Download all bundles for T-cells sequenced with 10x](tasks/Download%2010x%20Seq%20T-cell%20Bundles) |
-| :white_check_mark: | [Use scanpy to explore an expression matrix downloaded from the HCA browser](nov18_demo) |
-| :white_circle: | Additional scanpy/seurat examples with expression matrix downloaded from the HCA browser: Filter matrix |
-| :white_circle: | Additional scanpy/seurat examples with expression matrix downloaded from HCA browser: Identify marker genes |
-| :white_circle: | Download specific json ingest metadata in tabular format, and relate to an expression matrix |
 | :large_orange_diamond: | Compare QC metrics between one experiment and another |
+| :white_check_mark: | [Use scanpy to explore an expression matrix downloaded from the HCA browser](nov18_demo) |
+| :white_circle: | Filter expression matrix downloaded from the HCA browser |
+| :white_circle: | Identify marker genes in expression matrix downloaded from HCA browser |
+| :white_circle: | Download specific json ingest metadata in tabular format, and relate to an expression matrix |
 | :white_circle: | Check gene expression of key markers for immune cells |
 | :white_circle: | Compare averaged gene expression of neurons to bulk controls |
 | :white_circle: | Find most variable genes in monocytes across experiments |


### PR DESCRIPTION
cc @mckinsel 

Updated the list of tasks on the readme based on ideas from the Analysis Community meeting call (nov 28 2018), and added the HCA meeting demo to the task list.

related to https://github.com/HumanCellAtlas/data-consumer-vignettes/issues/24 based on motivation from @jodihir

added tasks:
Demonstrate how to find marker genes for each cell (i.e. from the scanpy/suerat tutorials)
How to filter a matrix (i.e. from the scanpy/suerat tutorials)
How to get all of the json ingest metadata into a tabular format, and how to relate that to the expression matrix from the matrix service

did not add but could add:
A lightweight way to link author annotations to a dataset

Do we need to remove any tasks?



