### PR TITLE
Bump wiremock version to address CVE-2017-7525

### DIFF
--- a/tasks/SPARK/pom.xml
+++ b/tasks/SPARK/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock</artifactId>
-            <version>2.18.0</version>
+            <version>2.24.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Closes #35 

It appears that there are only two dependencies that require jackson-databind, spark and wiremock. Of the two, only wiremock==2.18.0 is vulnerable.