### PR TITLE
Fix Travis builds being shown as passing when they are actually failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,6 @@ before_script:
 
 script:
 # Test that notebooks run successfully
-- find "$PWD" -name "*.ipynb" -exec sh test/test_notebook.sh "{}" \;
+- find "$PWD" -name "*.ipynb" -exec sh test/test_notebook.sh "{}" +
 # Naive test to check that output committed with notebook-
 - find . -name "*.ipynb" -exec sh test/test_output.sh "{}" \;

--- a/test/test_notebook.sh
+++ b/test/test_notebook.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 # test/test_output.sh path_to_notebook
 # See ReviewNB/treon#12 
-cd $(dirname $1)
+DIRECTORY=$(dirname "$1")
+cd "$DIRECTORY"
 treon


### PR DESCRIPTION
This PR addresses two problems:

* Because of the way that tests are run (with `find`, which calls `treon`), a test failure could be obscured, causing the Travis build to pass falsely. (Fix in `.travis.yml`.)
* Fixes a bug where notebooks would be tested with a CWD different than the immediate parent directory of the notebook, which caused the failures observed by @amarjandu in his [comment] on #66 .

Both of these fixes will become unnecessary once ReviewNB/treon#14 is released, presumably in `treon==0.1.3`.