### PR TITLE
[DO NOT MERGE] Raise an error from a notebook to test CI/CD checks

### DIFF
--- a/Find Cell Type Count/Find Cell Type Count.ipynb
+++ b/Find Cell Type Count/Find Cell Type Count.ipynb
@@ -13,6 +13,15 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "raise Exception(\"Raising an exception to see if tests fail too\")"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 9,
    "metadata": {},
    "outputs": [],
@@ -764,7 +773,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR is a spot check to follow up with #66, to verify that CI/CD is working as expected. We add one cell to a notebook that raises an exception, and see if this breaks the CI/CD system.