### PR TITLE
General test harness improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ cache: pip
 python:
 - 3.6
 - 3.7
-- 3.8
 
 install:
 # numpy requires some additional dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 dist: xenial  # for python3.7+ testing
 
+cache: pip
+
 python:
 - 3.6
 - 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
 - sudo apt-get update
 - sudo apt-get install libblas-dev liblapack-dev libatlas-base-dev gfortran libhdf5-dev
 - pip install -r test/requirements-dev.txt
-- find . -name "requirements.txt" -exec pip install -r "{}" \;
+- find . -name "requirements.txt" | tr '\n' '\0' | xargs -0 -n1 pip install -r
 
 script:
 # Test that notebooks run successfully

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,6 @@ before_script:
 
 script:
 # Test that notebooks run successfully
-- find "$PWD" -name "*.ipynb" -exec sh test/test_notebook.sh "{}" +
+- treon
 # Naive test to check that output committed with notebook-
 - find . -name "*.ipynb" -exec sh test/test_output.sh "{}" \;

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ script:
 # Test that notebooks run successfully
 - treon
 # Naive test to check that output committed with notebook-
-- find . -name "*.ipynb" -exec sh test/test_output.sh "{}" \;
+- find . -name "*.ipynb" | tr '\n' '\0' | xargs -0 -n1 sh test/test_output.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,8 @@ install:
 - pip install -r test/requirements-dev.txt
 - find . -name "requirements.txt" -exec pip install -r "{}" \;
 
-before_script:
-# To ignore a directory, we can just delete the directory
-# so that treon doesn't see it.
-- xargs -t rm -rf < test/ignore
-
 script:
 # Test that notebooks run successfully
-- treon
+- eval "treon $(awk '{printf " --exclude " $0}' test/ignore)"
 # Naive test to check that output committed with notebook-
 - find . -name "*.ipynb" | tr '\n' '\0' | xargs -0 -n1 sh test/test_output.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: python
-dist: xenial  # for python3.7+ testing
+dist: bionic
 
 cache: pip
 
 python:
 - 3.6
 - 3.7
-- 3.8-dev
+- 3.8
 
 install:
 # numpy requires some additional dependencies

--- a/test/README.md
+++ b/test/README.md
@@ -12,7 +12,7 @@ on Travis.
 
 The tests also check if output is committed with the notebook (which it should be).
 This test is naive - it tests if the number of code cells in a notebook is equal to
-the number of cell outputs in the same notebook.
+the number of cell outputs in the same notebook. (See `.travis.yml`.)
 
 ## Structure
 

--- a/test/requirements-dev.txt
+++ b/test/requirements-dev.txt
@@ -1,2 +1,2 @@
 -r requirements.txt
-treon==0.1.2
+treon==0.1.3

--- a/test/test_notebook.sh
+++ b/test/test_notebook.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-# test/test_output.sh path_to_notebook
-# See ReviewNB/treon#12 
-DIRECTORY=$(dirname "$1")
-cd "$DIRECTORY"
-treon

--- a/test/test_output.sh
+++ b/test/test_output.sh
@@ -1,7 +1,4 @@
 #!/bin/sh
 # test/test_output.sh 
-test $(grep -oc '"outputs": ' "$1") -eq $(grep -oc '"cell_type": "code"' "$1")
-if [ $? -gt 0 ]; then
-    echo "FAIL: Was output committed with this notebook? $1"
-fi
-exit 0
+echo $1
+test $(grep -oc '"outputs": ' "$1") -eq $(grep -oc '"cell_type": "code"' "$1") || exit 1


### PR DESCRIPTION
A bunch of miscellaneous improvements to the test harness.
* Upgrade to treon v0.1.3. This lets us remove some of the workaround code we have in repo. (Namely, running notebooks in the directories they live in, and ignoring certain notebooks.)
* Use Python 3.8 instead of 3.8-dev for Travis builds.
* Cache pip downloads between Travis builds.
* Fix numpy install failing on 3.8
* Fix output testing failing silently

This PR closes #89.

As a consequence of some of the changes above, build time has been cut from some 30 minutes to just over three minutes. Neat!