### PR TITLE
[EASY] Bump spark version: 2.3.3 -> 2.4.4

### DIFF
--- a/SPARK Example/pom.xml
+++ b/SPARK Example/pom.xml
@@ -9,12 +9,12 @@
         <dependency> <!-- Spark dependency -->
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_2.11</artifactId>
-            <version>2.3.3</version>
+            <version>2.4.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_2.11</artifactId>
-            <version>2.3.3</version>
+            <version>2.4.4</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/SPARK Example/pom.xml
+++ b/SPARK Example/pom.xml
@@ -12,6 +12,11 @@
             <version>2.4.4</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.10</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_2.11</artifactId>
             <version>2.4.4</version>


### PR DESCRIPTION
Modifies the `pom.xml` file in the Spark example to bump the Spark version to the latest (2.4.4, listed on https://spark.apache.org/downloads.html)

Closes #84