### PR TITLE
[EASY] Fix notebook path argument in scanpy readme

### DIFF
--- a/Explore an HCA Data Set in Scanpy (May 2019)/README.md
+++ b/Explore an HCA Data Set in Scanpy (May 2019)/README.md
@@ -54,7 +54,7 @@ $ pip install -r ./REQUIREMENTS.txt
 Start up the jupyter kernel, which will open a web browser.
 
 ```bash
-$ jupyter notebook --notebook-dir=`pwd`
+$ jupyter notebook --notebook-dir="$(pwd)"
 ```
 
 Once you have the notebook server running you can navigate to:


### PR DESCRIPTION
Fixes the way the `pwd` command result is passed to the Jupyter notebook command, to allow for spaces in the directory names

Closes #82 